### PR TITLE
[FLINK-22035] Add Github Actions

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -2,7 +2,7 @@ name: Run Flink Jira Bot Hourly
 
 on:
   schedule:
-      - cron: 0 * * * *
+      - cron: 33 9,21 * * *
 jobs:
   run:
     env:
@@ -22,4 +22,4 @@ jobs:
           pip install -r requirements.txt
       - name: Run Jira Bot
         run: |
-          python flink_jira_bot.py
+          python flink_jira_bot.py -d

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,0 +1,25 @@
+name: Run Flink Jira Bot Hourly
+
+on:
+  schedule:
+      - cron: 0 * * * *
+jobs:
+  run:
+    env:
+      JIRA_PASSWORD: ${{ secrets.FLINK_JIRA_BOT_PASSWORD }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run Jira Bot
+        run: |
+          python flink_jira_bot.py


### PR DESCRIPTION
**Attention** 
* This is still blocked on https://issues.apache.org/jira/browse/INFRA-21704. 
* Merging this will result in activation of the bot, which I would like to first sent an email to dev@f.a.o. 

Output of running this locally (in dry-run mode):
```
(flink-jira-bot) ➜  flink-jira-bot git:(FLINK-22035) ✗ act "schedule"                                                                                                                                                                                   (gke_vvp-stable-playground-150788_europe-west1-b_vvp-stable-1/minio)
[Run Flink Jira Bot Hourly/run] 🚀  Start image=catthehacker/ubuntu:act-latest
[Run Flink Jira Bot Hourly/run]   🐳  docker run image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Run Flink Jira Bot Hourly/run]   🐳  docker cp src=/home/knaufk/Documents/flink-repositories/flink-jira-bot/. dst=/home/knaufk/Documents/flink-repositories/flink-jira-bot
[Run Flink Jira Bot Hourly/run] ⭐  Run actions/checkout@v2
[Run Flink Jira Bot Hourly/run]   ✅  Success - actions/checkout@v2
[Run Flink Jira Bot Hourly/run] ⭐  Run Set up Python 3.9
[Run Flink Jira Bot Hourly/run]   ☁  git clone 'https://github.com/actions/setup-python' # ref=v2
[Run Flink Jira Bot Hourly/run]   🐳  docker cp src=/home/knaufk/.cache/act/actions-setup-python@v2 dst=/actions/
[Run Flink Jira Bot Hourly/run]   💬  ::debug::Semantic version spec of 3.9 is 3.9
[Run Flink Jira Bot Hourly/run]   💬  ::debug::isExplicit: 
[Run Flink Jira Bot Hourly/run]   💬  ::debug::explicit? false
[Run Flink Jira Bot Hourly/run]   💬  ::debug::evaluating 0 versions
[Run Flink Jira Bot Hourly/run]   💬  ::debug::match not found
| Version 3.9 was not found in the local cache
[Run Flink Jira Bot Hourly/run]   💬  ::debug::check 3.10.0-alpha.7 satisfies 3.9
[Run Flink Jira Bot Hourly/run]   💬  ::debug::check 3.10.0-alpha.6 satisfies 3.9
[Run Flink Jira Bot Hourly/run]   💬  ::debug::check 3.10.0-alpha.5 satisfies 3.9
[Run Flink Jira Bot Hourly/run]   💬  ::debug::check 3.10.0-alpha.4 satisfies 3.9
[Run Flink Jira Bot Hourly/run]   💬  ::debug::check 3.10.0-alpha.3 satisfies 3.9
[Run Flink Jira Bot Hourly/run]   💬  ::debug::check 3.10.0-alpha.2 satisfies 3.9
[Run Flink Jira Bot Hourly/run]   💬  ::debug::check 3.10.0-alpha.1 satisfies 3.9
[Run Flink Jira Bot Hourly/run]   💬  ::debug::check 3.9.4 satisfies 3.9
[Run Flink Jira Bot Hourly/run]   💬  ::debug::x64===x64 && darwin===linux
[Run Flink Jira Bot Hourly/run]   💬  ::debug::x64===x64 && linux===linux
[Run Flink Jira Bot Hourly/run]   💬  ::debug::x64===x64 && linux===linux
[Run Flink Jira Bot Hourly/run]   💬  ::debug::x64===x64 && linux===linux
[Run Flink Jira Bot Hourly/run]   💬  ::debug::matched 3.9.4
| Version 3.9 is available for downloading
| Download from "https://github.com/actions/python-versions/releases/download/3.9.4-103698/python-3.9.4-linux-20.04-x64.tar.gz"
[Run Flink Jira Bot Hourly/run]   💬  ::debug::Downloading https://github.com/actions/python-versions/releases/download/3.9.4-103698/python-3.9.4-linux-20.04-x64.tar.gz
[Run Flink Jira Bot Hourly/run]   💬  ::debug::Destination /tmp/102eaef6-4af6-4054-a0d3-074172195617
[Run Flink Jira Bot Hourly/run]   💬  ::debug::download complete
| Extract downloaded archive
[Run Flink Jira Bot Hourly/run]   💬  ::debug::Checking tar --version
[Run Flink Jira Bot Hourly/run]   💬  ::debug::tar (GNU tar) 1.30%0ACopyright (C) 2017 Free Software Foundation, Inc.%0ALicense GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.%0AThis is free software: you are free to change and redistribute it.%0AThere is NO WARRANTY, to the extent permitted by law.%0A%0AWritten by John Gilmore and Jay Fenlason.
| [command]/usr/bin/tar xz --warning=no-unknown-keyword -C /tmp/5ec11dc3-b21b-4031-ae22-dc22201c57da -f /tmp/102eaef6-4af6-4054-a0d3-074172195617
| Execute installation script
| Check if Python hostedtoolcache folder exist...
| Creating Python hostedtoolcache folder...
| Create Python 3.9.4 folder
| Copy Python binaries to hostedtoolcache folder
| Create additional symlinks (Required for the UsePythonVersion Azure Pipelines task and the setup-python GitHub Action)
| Upgrading PIP...
| Looking in links: /tmp/tmp_8xjbf90
| Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.9.4/x64/lib/python3.9/site-packages (49.2.1)
| Requirement already satisfied: pip in /opt/hostedtoolcache/Python/3.9.4/x64/lib/python3.9/site-packages (20.2.3)
| Collecting pip
| Downloading pip-21.0.1-py3-none-any.whl (1.5 MB)
| Installing collected packages: pip
| Successfully installed pip-21.0.1
| Create complete file
[Run Flink Jira Bot Hourly/run]   💬  ::debug::isExplicit: 
[Run Flink Jira Bot Hourly/run]   💬  ::debug::explicit? false
[Run Flink Jira Bot Hourly/run]   💬  ::debug::isExplicit: 3.9.4
[Run Flink Jira Bot Hourly/run]   💬  ::debug::explicit? true
[Run Flink Jira Bot Hourly/run]   💬  ::debug::evaluating 1 versions
[Run Flink Jira Bot Hourly/run]   💬  ::debug::matched: 3.9.4
[Run Flink Jira Bot Hourly/run]   💬  ::debug::checking cache: /opt/hostedtoolcache/Python/3.9.4/x64
[Run Flink Jira Bot Hourly/run]   💬  ::debug::Found tool in cache Python 3.9.4 x64
[Run Flink Jira Bot Hourly/run]   ⚙  ::add-path:: /opt/hostedtoolcache/Python/3.9.4/x64
[Run Flink Jira Bot Hourly/run]   ⚙  ::add-path:: /opt/hostedtoolcache/Python/3.9.4/x64/bin
[Run Flink Jira Bot Hourly/run]   ⚙  ::set-output:: python-version=3.9.4
| Successfully setup CPython (3.9.4)
[Run Flink Jira Bot Hourly/run]   ❓  ##[add-matcher]/actions/actions-setup-python@v2/.github/python.json
[Run Flink Jira Bot Hourly/run]   ✅  Success - Set up Python 3.9
[Run Flink Jira Bot Hourly/run] ⭐  Run Install dependencies
| Requirement already satisfied: pip in /opt/hostedtoolcache/Python/3.9.4/x64/lib/python3.9/site-packages (21.0.1)
| Collecting appdirs==1.4.4
|   Downloading appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)
| Collecting atlassian-python-api==3.8.0
|   Downloading atlassian-python-api-3.8.0.tar.gz (118 kB)
     |████████████████████████████████| 118 kB 2.0 MB/s 
|   Installing build dependencies ... done
|   Getting requirements to build wheel ... done
|     Preparing wheel metadata ... done
| Collecting black==20.8b1
|   Downloading black-20.8b1.tar.gz (1.1 MB)
     |████████████████████████████████| 1.1 MB 6.6 MB/s 
|   Installing build dependencies ... done
|   Getting requirements to build wheel ... done
|     Preparing wheel metadata ... done
| Collecting certifi==2020.12.5
|   Downloading certifi-2020.12.5-py2.py3-none-any.whl (147 kB)
     |████████████████████████████████| 147 kB 5.4 MB/s 
| Collecting chardet==4.0.0
|   Downloading chardet-4.0.0-py2.py3-none-any.whl (178 kB)
     |████████████████████████████████| 178 kB 5.3 MB/s 
| Collecting click==7.1.2
|   Downloading click-7.1.2-py2.py3-none-any.whl (82 kB)
     |████████████████████████████████| 82 kB 882 kB/s 
| Collecting confuse==1.4.0
|   Downloading confuse-1.4.0-py2.py3-none-any.whl (21 kB)
| Collecting Deprecated==1.2.12
|   Downloading Deprecated-1.2.12-py2.py3-none-any.whl (9.5 kB)
| Collecting idna==2.10
|   Downloading idna-2.10-py2.py3-none-any.whl (58 kB)
     |████████████████████████████████| 58 kB 2.4 MB/s 
| Collecting mypy-extensions==0.4.3
|   Downloading mypy_extensions-0.4.3-py2.py3-none-any.whl (4.5 kB)
| Collecting oauthlib==3.1.0
|   Downloading oauthlib-3.1.0-py2.py3-none-any.whl (147 kB)
     |████████████████████████████████| 147 kB 5.0 MB/s 
| Collecting pathspec==0.8.1
|   Downloading pathspec-0.8.1-py2.py3-none-any.whl (28 kB)
| Collecting pycparser==2.20
|   Downloading pycparser-2.20-py2.py3-none-any.whl (112 kB)
     |████████████████████████████████| 112 kB 5.0 MB/s 
| Collecting PyYAML==5.4.1
|   Downloading PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl (630 kB)
     |████████████████████████████████| 630 kB 4.8 MB/s 
| Collecting regex==2021.4.4
|   Downloading regex-2021.4.4-cp39-cp39-manylinux2014_x86_64.whl (730 kB)
     |████████████████████████████████| 730 kB 1.6 MB/s 
| Collecting requests==2.25.1
|   Downloading requests-2.25.1-py2.py3-none-any.whl (61 kB)
     |████████████████████████████████| 61 kB 3.2 MB/s 
| Collecting requests-oauthlib==1.3.0
|   Downloading requests_oauthlib-1.3.0-py2.py3-none-any.whl (23 kB)
| Collecting six==1.15.0
|   Downloading six-1.15.0-py2.py3-none-any.whl (10 kB)
| Collecting toml==0.10.2
|   Downloading toml-0.10.2-py2.py3-none-any.whl (16 kB)
| Collecting typed-ast==1.4.3
|   Downloading typed_ast-1.4.3-cp39-cp39-manylinux1_x86_64.whl (769 kB)
     |████████████████████████████████| 769 kB 3.6 MB/s 
| Collecting typing-extensions==3.7.4.3
|   Downloading typing_extensions-3.7.4.3-py3-none-any.whl (22 kB)
| Collecting urllib3==1.26.4
|   Downloading urllib3-1.26.4-py2.py3-none-any.whl (153 kB)
     |████████████████████████████████| 153 kB 3.5 MB/s 
| Collecting wrapt==1.12.1
|   Downloading wrapt-1.12.1.tar.gz (27 kB)
| Using legacy 'setup.py install' for wrapt, since package 'wheel' is not installed.
| Building wheels for collected packages: atlassian-python-api, black
|   Building wheel for atlassian-python-api (PEP 517) ... done
|   Created wheel for atlassian-python-api: filename=atlassian_python_api-3.8.0-py3-none-any.whl size=129674 sha256=3a75182f7bc1ca029ebb7dcd3a151f7815bb33fa4b78f48fef50edcf8f6f3f89
|   Stored in directory: /home/knaufk/Documents/flink-repositories/home/.cache/pip/wheels/54/5a/97/1c56179ca4ad5c496ad11ee2d55ea3a6ef756f770d67a42c8c
|   Building wheel for black (PEP 517) ... done
|   Created wheel for black: filename=black-20.8b1-py3-none-any.whl size=124184 sha256=2ca001413304deab8209a879ae2834a496d0b044914f11d47386775dffcb6d81
|   Stored in directory: /home/knaufk/Documents/flink-repositories/home/.cache/pip/wheels/4e/57/9a/e704bdd859ee892dc46fff03fd499422dc9e99fd9bd5c446d3
| Successfully built atlassian-python-api black
| Installing collected packages: urllib3, idna, chardet, certifi, wrapt, requests, oauthlib, typing-extensions, typed-ast, toml, six, requests-oauthlib, regex, PyYAML, pathspec, mypy-extensions, Deprecated, click, appdirs, pycparser, confuse, black, atlassian-python-api
|     Running setup.py install for wrapt ... done
| Successfully installed Deprecated-1.2.12 PyYAML-5.4.1 appdirs-1.4.4 atlassian-python-api-3.8.0 black-20.8b1 certifi-2020.12.5 chardet-4.0.0 click-7.1.2 confuse-1.4.0 idna-2.10 mypy-extensions-0.4.3 oauthlib-3.1.0 pathspec-0.8.1 pycparser-2.20 regex-2021.4.4 requests-2.25.1 requests-oauthlib-1.3.0 six-1.15.0 toml-0.10.2 typed-ast-1.4.3 typing-extensions-3.7.4.3 urllib3-1.26.4 wrapt-1.12.1
[Run Flink Jira Bot Hourly/run]   ✅  Success - Install dependencies
[Run Flink Jira Bot Hourly/run] ⭐  Run Test with pytest
| INFO:root:Looking for minor tickets, which were previously marked as stale: project=FLINK AND Priority = Minor AND resolution = Unresolved AND labels in ("stale-minor") AND updated < startOfDay(-7d)
| INFO:root:Looking for minor tickets, which are stale: project = FLINK AND Priority = Minor AND resolution = Unresolved AND updated < startOfDay(-180d)
| INFO:root:Found https://issues.apache.org/jira/browse/FLINK-19593. It is marked stale now.
| INFO:root:DRY RUN (FLINK-19593): Adding label "stale-minor".
| INFO:root:DRY_RUN (FLINK-19593): Adding comment "This issue and all of its Sub-Tasks have not been updated for 180 days. So, it has been labeled "stale-minor". If you are still affected by this bug or are still interested in this issue, please give an update and remove the label. In 7 days the issue will be closed automatically.".
| INFO:root:Found https://issues.apache.org/jira/browse/FLINK-19443. It is marked stale now.
| INFO:root:DRY RUN (FLINK-19443): Adding label "stale-minor".
| INFO:root:DRY_RUN (FLINK-19443): Adding comment "This issue and all of its Sub-Tasks have not been updated for 180 days. So, it has been labeled "stale-minor". If you are still affected by this bug or are still interested in this issue, please give an update and remove the label. In 7 days the issue will be closed automatically.".
...
```
``